### PR TITLE
Add support for Python 2.7

### DIFF
--- a/moj_irat/healthchecks.py
+++ b/moj_irat/healthchecks.py
@@ -220,10 +220,10 @@ class HealthcheckRegistry(object):
                     )
             except Exception as e:
                 response = HealthcheckResponse(
-                        name=get_healthcheck_name(healthcheck),
-                        status=False,
-                        exception=str(e),
-                        exception_class=e.__class__.__name__,
+                    name=get_healthcheck_name(healthcheck),
+                    status=False,
+                    exception=str(e),
+                    exception_class=e.__class__.__name__,
                 )
             responses.append(response)
         return responses

--- a/moj_irat/healthchecks.py
+++ b/moj_irat/healthchecks.py
@@ -134,7 +134,10 @@ class JsonUrlHealthcheck(UrlHealthcheck):
     """
 
     def success_response(self, url_response):
-        response = super().success_response(url_response)
+        response = super(
+            JsonUrlHealthcheck,
+            self
+        ).success_response(url_response)
         try:
             response.kwargs['response'] = url_response.json()
         except ValueError:

--- a/moj_irat/tests/test_healthchecks_json.py
+++ b/moj_irat/tests/test_healthchecks_json.py
@@ -1,7 +1,10 @@
 import gc
 import re
 import sys
-from unittest import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 
 from django.core.urlresolvers import reverse
 from django.test.utils import override_settings

--- a/moj_irat/tests/test_ping_json.py
+++ b/moj_irat/tests/test_ping_json.py
@@ -1,5 +1,8 @@
 import json
-from unittest import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 
 from django.core.exceptions import ImproperlyConfigured
 from django.core.urlresolvers import reverse

--- a/moj_irat/views.py
+++ b/moj_irat/views.py
@@ -26,7 +26,7 @@ class PingJsonView(View):
         if not kwargs.get('build_date_key') or not kwargs.get('commit_id_key'):
             raise ImproperlyConfigured('ping.json schema requires build_date_key and '
                                        'commit_id_key to be provided')
-        super().__init__(**kwargs)
+        super(PingJsonView, self).__init__(**kwargs)
 
     def get(self, request):
         response_data = {

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,13 @@
 import os
 from setuptools import setup
+import sys
 
 with open(os.path.join(os.path.dirname(__file__), 'README.rst')) as readme:
     README = readme.read()
+
+tests_require = ['responses>=0.5']
+if sys.version_info < (3, 3):
+    tests_require.append('mock>=1.3')
 
 # allow setup.py to be run from any path
 os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
@@ -24,5 +29,5 @@ setup(
         'Programming Language :: Python :: 3.4',
     ],
     test_suite='runtests.runtests',
-    tests_require=['responses>=0.5', 'mock>=1.3']
+    tests_require=tests_require
 )

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
 
 setup(
     name='django-moj-irat',
-    version='0.2',
+    version='0.3',
     packages=['moj_irat'],
     include_package_data=True,
     license='BSD License',
@@ -20,8 +20,9 @@ setup(
     classifiers=[
         'Framework :: Django',
         'Intended Audience :: MoJ Developers',
+        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3.4',
     ],
     test_suite='runtests.runtests',
-    tests_require=['responses>=0.5']
+    tests_require=['responses>=0.5', 'mock>=1.3']
 )


### PR DESCRIPTION
`unittest.mock` has been backported as `mock` for Python2.6+ (although it appears to present itself just as `mock`, not `unittest.mock`), and we can use old-style `super()` calls, too.

This will allow Python 2.7 projects (like [Courtfinder search](http://github.com/ministryofjustice/courtfinder-search)) to benefit from this library.