### PR TITLE
Add CORS header to ping.json view

### DIFF
--- a/moj_irat/tests/test_ping_json.py
+++ b/moj_irat/tests/test_ping_json.py
@@ -101,3 +101,15 @@ class PingJsonViewTestCase(TestCase):
             'version_number': 'master.latest',
             'build_tag': 'TEST Django Utils',
         })
+
+    def test_cors_header_is_set_correctly(self):
+        env = {
+            'DOCKER_IMAGE_DATE': '2015-12-04T10:00:00+0000',
+            'DOCKER_IMAGE_SHA': 'e9866935d3c5d19adc48e0be3ad3f2718b86bfe4',
+        }
+        with mock.patch.dict('os.environ', env):
+            response, response_json = self.call_ping_json_view(
+                build_date_key='DOCKER_IMAGE_DATE',
+                commit_id_key='DOCKER_IMAGE_SHA',
+            )
+        self.assertEqual('*', response['access-control-allow-origin'])

--- a/moj_irat/views.py
+++ b/moj_irat/views.py
@@ -37,6 +37,9 @@ class PingJsonView(View):
         response = JsonResponse(response_data)
         if not response_data['build_date'] or not response_data['commit_id']:
             response.status_code = 501
+
+        response['Access-Control-Allow-Origin'] = '*'
+
         return response
 
 


### PR DESCRIPTION
It would be useful to be able to load the ping.json from other domains
in single page apps. For example; an app that shows the app versions
deployed into each environment.