### PR TITLE
v0.11: Support for Django 5.2/Python 3.13

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,6 +36,10 @@ jobs:
           - { "django-version": "5.1", "python-version": "3.10" }
           - { "django-version": "5.1", "python-version": "3.11" }
           - { "django-version": "5.1", "python-version": "3.12" }
+          - { "django-version": "5.2", "python-version": "3.10" }
+          - { "django-version": "5.2", "python-version": "3.11" }
+          - { "django-version": "5.2", "python-version": "3.12" }
+          - { "django-version": "5.2", "python-version": "3.13" }
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/README.rst
+++ b/README.rst
@@ -48,6 +48,9 @@ Alternatively, you can use ``tox`` if you have multiple python versions.
 History
 -------
 
+0.11
+    Add experimental support for Django 5.2/Python 3.13.
+
 0.10
     Add experimental support for Django versions 5.0 & 5.1.
 

--- a/moj_irat/__init__.py
+++ b/moj_irat/__init__.py
@@ -1,2 +1,2 @@
-VERSION = (0, 10)
+VERSION = (0, 11)
 __version__ = '.'.join(map(str, VERSION))

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,6 +24,7 @@ classifiers =
     Framework :: Django :: 4.2
     Framework :: Django :: 5.0
     Framework :: Django :: 5.1
+    Framework :: Django :: 5.2
     Intended Audience :: Developers
     License :: OSI Approved :: MIT License
     Natural Language :: English
@@ -35,6 +36,7 @@ classifiers =
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3.12
+    Programming Language :: Python :: 3.13
 
 [options]
 ; NB: looser python version requirement than what's tested
@@ -43,7 +45,7 @@ packages =
     moj_irat
 include_package_data = true
 install_requires =
-    Django>=2.2,<5.2
+    Django>=2.2,<5.3
     requests
 
 [flake8]

--- a/tox.ini
+++ b/tox.ini
@@ -10,6 +10,7 @@ envlist =
     {py38,py39,py310,py311,py312}-django42
     {py310,py311,py312}-django50
     {py310,py311,py312}-django51
+    {py310,py311,py312,py313}-django52
     lint
 
 [testenv]
@@ -25,6 +26,7 @@ deps =
     django42: django~=4.2.0
     django50: django~=5.0.0
     django51: django~=5.1.0
+    django51: django~=5.2.0
 commands = python -m tests
 
 [testenv:lint]


### PR DESCRIPTION
Current version can't be installed alongside Django 5.2.